### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Workflow upload report to Codecov
 on: 
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/upa-io/codecov-java/security/code-scanning/3](https://github.com/upa-io/codecov-java/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, sets up Java, installs dependencies, runs tests, and uploads coverage to Codecov (which uses its own token), it only needs read access to repository contents. Therefore, add `permissions: contents: read` at the top level of the workflow (just after the `name:` line), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
